### PR TITLE
add enforce option and pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: go-carpet
+  name: go-carpet
+  entry: .pre-commit-runner.sh
+  language: script
+  files: \.go
+  description: enforce a minimum level of coverage on changed files
+  args:
+    - "-mincov=50"

--- a/.pre-commit-runner.sh
+++ b/.pre-commit-runner.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+args=""
+while [ $# -gt 0 ]; do
+    if [[ "$1" == -* ]]; then
+        args+="$1"
+    else
+        space_files=$@
+        files=${space_files// /,}
+        break
+    fi
+    shift
+done
+
+go-carpet -summary -enforce $args -file $files

--- a/README.md
+++ b/README.md
@@ -22,25 +22,53 @@ Usage
 
     usage: go-carpet [options] [paths]
       -256colors
-        	use more colors on 256-color terminal (indicate the level of coverage)
-      -args string
-        	pass additional arguments for go test
-      -file string
-        	comma-separated list of files to test (default: all)
-      -func string
-        	comma-separated functions list (default: all functions)
+            use more colors on 256-color terminal (indicate the level of coverage)
+      -args arguments
+            pass additional arguments for go test
+      -enforce
+            fail if any file's coverage is below mincov
+      -file files
+            comma-separated list of files to test (default: all)
+      -func functions
+            comma-separated functions list (default: all functions)
       -include-vendor
-        	include vendor directories for show coverage (Godeps, vendor)
+            include vendor directories for show coverage (Godeps, vendor)
       -mincov float
-        	coverage threshold of the file to be displayed (in percent) (default 100)
+            coverage threshold of the file to be displayed (in percent) (default 100)
       -summary
-        	only show summary for each file
+            only show summary for each file
       -version
-        	get version
+            get version
 
 For view coverage in less, use `-R` option:
 
     go-carpet | less -R
+
+As a pre-commit hook
+--------------------
+
+[Pre-commit](https://pre-commit.com) is a tool that makes it easy to run checks on every Git commit.
+You can use `go-carpet` as a pre-commit hook by installing pre-commit and including the following
+in your `.pre-commit-config.yaml`:
+
+```
+repos:
+  ...
+  - repo: https://github.com/msoap/go-carpet
+    rev: v1.11.0
+    hooks:
+      - id: go-carpet
+```
+
+By default, `go-carpet` will enforce 50% test coverage on every changed file.  You can customize
+the threshold in your hook with an arguments block as follows:
+
+```
+args:
+  - "-mincov=X"
+```
+
+You must have `go-carpet` installed in your PATH for this pre-commit hook to work.
 
 Install
 -------

--- a/go-carpet.1
+++ b/go-carpet.1
@@ -27,12 +27,16 @@ usage: go\-carpet [options] [paths]
         use more colors on 256\-color terminal (indicate the level of coverage)
   \-args string
         pass additional arguments for go test
+  \-enforce
+        fail if any file's coverage is below mincov
   \-file string
         comma\-separated list of files to test (default: all)
   \-func string
         comma\-separated functions list (default: all functions)
   \-include\-vendor
         include vendor directories for show coverage (Godeps, vendor)
+  \-mincov float
+        coverage threshold of the file to be displayed (in percent) (default 100)
   \-summary
         only show summary for each file
   \-version

--- a/go-carpet.go
+++ b/go-carpet.go
@@ -161,7 +161,7 @@ func getCoverForDir(coverFileName string, filesFilter []string, config Config) (
 
 	for _, fileProfile := range coverProfile {
 		// Skip files if minimal coverage is set and is covered more than minimal coverage
-		if config.minCoverage > 0 && config.minCoverage < 100.0 && getStatForProfileBlocks(fileProfile.Blocks) > config.minCoverage {
+		if config.minCoverage >= 0 && config.minCoverage <= 100.0 && getStatForProfileBlocks(fileProfile.Blocks) >= config.minCoverage {
 			continue
 		}
 

--- a/go-carpet.go
+++ b/go-carpet.go
@@ -429,9 +429,11 @@ func goCarpet() int {
 	}
 
 	someFileBelowMin := false
+	testsPass := true
 	for _, path := range testDirs {
 		if err = runGoTest(path, coverFileName, additionalArgs, false); err != nil {
 			log.Print(err)
+			testsPass = false
 			continue
 		}
 
@@ -460,7 +462,7 @@ func goCarpet() int {
 		}
 	}
 
-	if someFileBelowMin && config.enforceCoverage {
+	if !testsPass || (someFileBelowMin && config.enforceCoverage) {
 		return 1
 	}
 

--- a/unix_only_test.go
+++ b/unix_only_test.go
@@ -10,14 +10,14 @@ import (
 
 func Test_getCoverForDir(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
-		_, _, err := getCoverForDir("./testdata/not_exists.out", []string{}, Config{colors256: false})
+		_, _, _, err := getCoverForDir("./testdata/not_exists.out", []string{}, Config{colors256: false})
 		if err == nil {
 			t.Errorf("1. getCoverForDir() error failed")
 		}
 	})
 
 	t.Run("cover", func(t *testing.T) {
-		bytes, _, err := getCoverForDir("./testdata/cover_00.out", []string{}, Config{colors256: false})
+		bytes, _, _, err := getCoverForDir("./testdata/cover_00.out", []string{}, Config{colors256: false})
 		if err != nil {
 			t.Errorf("2. getCoverForDir() failed: %v", err)
 		}
@@ -31,7 +31,7 @@ func Test_getCoverForDir(t *testing.T) {
 	})
 
 	t.Run("cover with 256 colors", func(t *testing.T) {
-		bytes, _, err := getCoverForDir("./testdata/cover_00.out", []string{}, Config{colors256: true})
+		bytes, _, _, err := getCoverForDir("./testdata/cover_00.out", []string{}, Config{colors256: true})
 		if err != nil {
 			t.Errorf("5. getCoverForDir() failed: %v", err)
 		}
@@ -45,14 +45,14 @@ func Test_getCoverForDir(t *testing.T) {
 	})
 
 	t.Run("cover with 256 colors with error", func(t *testing.T) {
-		_, _, err := getCoverForDir("./testdata/cover_01.out", []string{}, Config{colors256: true})
+		_, _, _, err := getCoverForDir("./testdata/cover_01.out", []string{}, Config{colors256: true})
 		if err == nil {
 			t.Errorf("8. getCoverForDir() not exists go file")
 		}
 	})
 
 	t.Run("cover 01 without 256 colors", func(t *testing.T) {
-		bytes, _, err := getCoverForDir("./testdata/cover_00.out", []string{"file_01.go"}, Config{colors256: false})
+		bytes, _, _, err := getCoverForDir("./testdata/cover_00.out", []string{"file_01.go"}, Config{colors256: false})
 		if err != nil {
 			t.Errorf("9. getCoverForDir() failed: %v", err)
 		}
@@ -66,7 +66,7 @@ func Test_getCoverForDir(t *testing.T) {
 	})
 
 	t.Run("cover 02 without 256 colors", func(t *testing.T) {
-		bytes, _, err := getCoverForDir("./testdata/cover_02.out", []string{}, Config{colors256: false})
+		bytes, _, _, err := getCoverForDir("./testdata/cover_02.out", []string{}, Config{colors256: false})
 		if err != nil {
 			t.Errorf("12. getCoverForDir() failed: %v", err)
 		}
@@ -88,7 +88,7 @@ func Test_getCoverForDir_mincov_flag(t *testing.T) {
 		}
 
 		// cover_00.out has 100% coverage of 2 files
-		_, profileBlocks, err := getCoverForDir("./testdata/cover_00.out", []string{"file_01.go"}, conf)
+		_, belowMin, profileBlocks, err := getCoverForDir("./testdata/cover_00.out", []string{"file_01.go"}, conf)
 		if err != nil {
 			t.Errorf("getCoverForDir() failed with error: %s", err)
 		}
@@ -99,6 +99,10 @@ func Test_getCoverForDir_mincov_flag(t *testing.T) {
 		if expectLen != actualLen {
 			t.Errorf("1. minimum coverage 100%% should print all the blocks. want %v, got: %v", expectLen, actualLen)
 		}
+
+		if !belowMin {
+			t.Errorf("1. at least one file was below minimum, but we didn't detect it")
+		}
 	})
 
 	t.Run("covered 100% mincov 50%", func(t *testing.T) {
@@ -108,7 +112,7 @@ func Test_getCoverForDir_mincov_flag(t *testing.T) {
 		}
 
 		// cover_00.out has 100% coverage of 2 files
-		_, profileBlocks, err := getCoverForDir("./testdata/cover_00.out", []string{"file_01.go"}, conf)
+		_, belowMin, profileBlocks, err := getCoverForDir("./testdata/cover_00.out", []string{"file_01.go"}, conf)
 		if err != nil {
 			t.Errorf("getCoverForDir() failed with error: %s", err)
 		}
@@ -118,6 +122,10 @@ func Test_getCoverForDir_mincov_flag(t *testing.T) {
 
 		if expectLen != actualLen {
 			t.Errorf("2. minimum coverage 50%% for 100%% covered source should print nothing. want %v, got: %v", expectLen, actualLen)
+		}
+
+		if belowMin {
+			t.Errorf("2. all files were above minimum coverage but we thought one wasn't")
 		}
 	})
 }


### PR DESCRIPTION
This PR adds an `-enforce` option to go-carpet that makes the executable return 1 if any file has coverage under the specified `-mincov` value.  It also adds a `.pre-commit-hooks.yaml` file and a `.pre-commit-runner.sh` which lets users perform coverage checks as a part of [pre-commit](https://pre-commit.com/).

There's a funny quirk with how pre-commit passes arguments to executables: it just specifies a list of (space-separated) arguments, followed by a list of (space-separated) file names to check.  If we want users to be able to customize the `-mincov` value (or pass any other arguments in) for `go-carpet`, we need to have some way to differentiate between an "argument" and a "filename".

The best I've been able to come up with is to check for arguments that start with a `-` character.  These are treated as arguments to `go-carpet`, and everything else gets concatenated together as a list of files.

Please let me know what you think, or if you have any suggestions/concerns!

